### PR TITLE
Add basic configuration for Github actions and badges in README

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Unittests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      # TODO requirements.txt needs to be fixed, for now let's just install networkx directly
+      run: pip3 install networkx==2.4
+      #run: |
+      #  python -m pip install --upgrade pip
+      #  pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      # The other tests require Gurobi, let's whitelist at least the other tests for now:
+      run: |
+        pip install pytest
+        PYTHONPATH=$PYTHONPATH:$PWD python3 -m pytest -ra \
+          unittests.py::TestApprovalMultiwinner::test_createprofiles \
+          unittests.py::TestApprovalMultiwinner::test_monroescore \
+          unittests.py::TestApprovalMultiwinner::test_mwrules__toofewcandidates

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Unittests badge](https://github.com/lumbric/abcvoting/workflows/Unittests/badge.svg)
+
 # abcvoting
 
 ## Python implementations of approval-based committee (multi-winner) rules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Unittests badge](https://github.com/lumbric/abcvoting/workflows/Unittests/badge.svg)
+[![MIT License](https://img.shields.io/github/license/martinlackner/abcvoting.svg)](https://choosealicense.com/licenses/mit/)
+[![Unittests badge](https://github.com/martinlackner/abcvoting/workflows/Unittests/badge.svg)](https://github.com/martinlackner/abcvoting/actions)
 
 # abcvoting
 


### PR DESCRIPTION
This adds a basic configuration for Github actions which runs the unittest.py using pytest. It runs only the tests which succeed without Gurobi. Badges for license and unittests are added to the README file.

Probably it would be nice to find a solution for Gurubi in future (e.g. use cvxpy and use an opensource solver on the CI server).

flake8 warnings should be fixed in future or explicitly ignored (in a tox.ini configuration or in the unittest.yml as command line argument). Then flake8 should be configured to trigger build errors in case of pep8 violations.

After the pull request is merged, the first Github actions job should be triggered automatically, because Github are enabled by default for all repositories.

I haven't enabled Python 2.7, because installing pytest failed, although I'm not sure why:
https://github.com/lumbric/abcvoting/runs/497777249?check_suite_focus=true