### PR TITLE
Remove obsolete future imports

### DIFF
--- a/abcvoting/abcrules.py
+++ b/abcvoting/abcrules.py
@@ -2,7 +2,6 @@
 """Approval-based committee (ABC) voting rules"""
 
 
-from __future__ import print_function
 import sys
 import functools
 from itertools import combinations

--- a/abcvoting/abcrules_cvxpy.py
+++ b/abcvoting/abcrules_cvxpy.py
@@ -3,8 +3,6 @@ Approval-based committee (ABC) rules implemented as a integer linear
 programs (ILPs) with CVXPY.
 """
 
-from __future__ import print_function
-
 try:
     import cvxpy as cp
 

--- a/abcvoting/abcrules_gurobi.py
+++ b/abcvoting/abcrules_gurobi.py
@@ -3,8 +3,6 @@ Approval-based committee (ABC) rules implemented as a integer linear
 programs (ILPs) with Gurobi (https://www.gurobi.com/)
 """
 
-from __future__ import print_function
-
 try:
     import gurobipy as gb
 

--- a/abcvoting/fileio.py
+++ b/abcvoting/fileio.py
@@ -3,7 +3,6 @@ Read preflib files (soi, toi, soc or toc)
 """
 
 
-from __future__ import print_function
 import os
 from abcvoting.preferences import Profile, ApprovalSet
 from math import ceil

--- a/abcvoting/misc.py
+++ b/abcvoting/misc.py
@@ -3,9 +3,6 @@ Miscellaneous functions for committees (i.e., subsets of candidates)
 """
 
 
-from __future__ import print_function
-
-
 def sort_committees(committees):
     """
     sorts a list of committees,

--- a/examples/allrules.py
+++ b/examples/allrules.py
@@ -2,7 +2,6 @@
 Compute all implemented ABC rules for a profile
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/examples/handling_preflib_files.py
+++ b/examples/handling_preflib_files.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import os
 

--- a/examples/random_profiles.py
+++ b/examples/random_profiles.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import random
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -2,7 +2,6 @@
 Very simple example (compute PAV)
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example01.py
+++ b/survey/example01.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example02.py
+++ b/survey/example02.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example03.py
+++ b/survey/example03.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example04.py
+++ b/survey/example04.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example05.py
+++ b/survey/example05.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example06.py
+++ b/survey/example06.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example07.py
+++ b/survey/example07.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example08.py
+++ b/survey/example08.py
@@ -5,7 +5,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example09.py
+++ b/survey/example09.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example10.py
+++ b/survey/example10.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example11.py
+++ b/survey/example11.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example12.py
+++ b/survey/example12.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/example13.py
+++ b/survey/example13.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/propositionA2.py
+++ b/survey/propositionA2.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/propositionA3.py
+++ b/survey/propositionA3.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/propositionA4.py
+++ b/survey/propositionA4.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/remark02.py
+++ b/survey/remark02.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "..")

--- a/survey/remark03.py
+++ b/survey/remark03.py
@@ -4,7 +4,6 @@ Axioms, Algorithms, and Applications"
 by Martin Lackner and Piotr Skowron
 """
 
-from __future__ import print_function
 import sys
 
 sys.path.insert(0, "../..")


### PR DESCRIPTION
Python 2 support is dropped now, this is a remaining cleanup of #27.