### PR TITLE
migrate pytest.ini to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,15 @@ norecursedirs = [
     "__pycache__",
 ]
 
+markers = [
+    "gurobi: a test that requires Gurobi (gurpbipy)",
+    "scip: a test that requires SCIP",
+    "glpk_mi: a test that requires glpk_mi",
+    "cbc: a test that requires CBC",
+    "cvxpy: a test that requires cvxpy",
+]
+
+
 [tool.coverage.run]
 # https://coverage.readthedocs.io/en/latest/config.html
 branch = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 networkx>=2.2
-pytest>=4.6
+pytest>=6
 coverage>=5.3
 black==20.8b1

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-markers =
-    gurobi: a test that requires Gurobi (gurpbipy)
-    scip: a test that requires SCIP,
-    glpk_mi: a test that requires glpk_mi,
-    cbc: a test that requires CBC,
-    cvxpy: a test that requires cvxpy,


### PR DESCRIPTION
This is just an aesthetic change, no real objective improvement. Note that it requires pytest >= 6 to use pyproject.toml.

Feel free to reject, if you prefer the old method. I don't see any important reason to go for the new way, except because we can.