### PR TITLE
Fix wrong test_output skips and set mip to non verbose

### DIFF
--- a/abcvoting/abcrules_mip.py
+++ b/abcvoting/abcrules_mip.py
@@ -44,6 +44,7 @@ def _optimize_rule_mip(set_opt_model_func, profile, committeesize, scorefct, res
     #  cases to avoid endless hanging computations, e.g. when CI runs the tests
     while True:
         model = mip.Model(solver_name=solver_id)
+        model.verbose = 0  # TODO could be set to 1, if abcvoting's verbose is set to >= 2
 
         # `in_committee` is a binary variable indicating whether `cand` is in the committee
         in_committee = [

--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -838,14 +838,9 @@ def test_output(capfd, rule_id, algorithm, resolute, verbose):
         # This message appears only sometimes, so even if this test succeeds for gurobi with
         # verbose=0, it's probably just due to the test execution order, i.e. the undesired
         # message was simply printed earlier, or caused by use of different Gurobi versions.
+        #
+        # This might skip too much, if gurobi is not the fastest.
         pytest.skip("Gurbi always prints something when used with academic license")
-    if "mip_cbc" == algorithm and verbose == 0:
-        # TODO don't understand why, but this test prints the Gurobi message too...
-        pytest.skip("MIP prints Gurobi messages for weird reasons")
-
-    if algorithm.startswith("mip_") and verbose == 0:
-        # TODO mip produces lots of output
-        pytest.skip("mip prints lots of messages")
 
     profile = Profile(2)
     profile.add_voters([[0]])


### PR DESCRIPTION
The Gurobi output in mip was probably caused by a bug. Now mip is set to
non-verbose, so we can unskip more tests.