### PR TITLE
Make output unit tests more robust

### DIFF
--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -2,6 +2,8 @@
 Unit tests for abcrules.py and abcrules_gurobi.py and abcrules_cvxpy.py
 """
 
+import re
+
 import pytest
 
 from abcvoting.abcrules_cvxpy import cvxpy_thiele_methods
@@ -482,14 +484,19 @@ def idfn(val):
 
 def remove_solver_output(out):
     """Remove extra, unwanted solver output (e.g. from Gurobi)."""
-    out = out.split("\n")
-    out = [
-        line
-        for line in out
-        if not line.startswith("Academic license - for non-commercial use only")
-    ]
-    out = [line for line in out if not line.startswith("Using license file")]
-    out = "\n".join(out)
+    filter_patterns = (
+        (
+            "\n--------------------------------------------\n"
+            "Warning: your license will expire in .*\n"
+            "--------------------------------------------\n\n"
+        ),
+        "Using license file.*\n",
+        "Academic license - for non-commercial use only.*\n",
+    )
+
+    for filter_pattern in filter_patterns:
+        out = re.sub(filter_pattern, "", out)
+
     return out
 
 


### PR DESCRIPTION
Turns out that Gurobi prints an additional warning before the license
expires. This has to be filtered too before running assert statements.
Since multiple dashes are used elsewhere too (which should not be
removed) and we do need to filter also new line characters, all filters
were changed to use regex replacement.