### PR TITLE
Fetch all tags and branches in GH actions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # fetch all tags to be able to generate a version number for test packages
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ def read_version():
     if git_describe.returncode == 0:
         git_version = git_describe.stdout.strip().decode("utf-8")
     else:
-        # per default no tags available in Github actions, but also no real need for a version
+        # per default no old commit are fetched in Github actions, that means, that git describe
+        # fails if the latest commit is not a tag, because old tags can't be found.
         git_version = "0.0.0"
 
     if git_version[0] == "v":


### PR DESCRIPTION
This should fix PyPI test package version clashes.