### PR TITLE
Use proper version string syntax for dev packages

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -65,6 +65,11 @@ jobs:
     # tests the package, the release is done in build.yml
     - name: Build a binary wheel and a source tarball
       run: python setup.py bdist_wheel
+      env:
+        # does not increment on re-run... :(
+        # this means this will fail in the last step, when uploading the same package again to PyPI
+        # because PyPI requires unique file names for uploaded packages
+        BUILD_NUMBER: ${{ github.run_number }}
 
     # tests uploading the package to the test repo, but only if API_KEY is defined
     - name: Publish distribution package to Test PyPI


### PR DESCRIPTION
Version string should now comply with PEP 440 and therefore fix unit
tests on Github.