### PR TITLE
add the missing bipartite_matching to the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
     ],
-    packages=["abcvoting"],
+    packages=["abcvoting", "abcvoting.bipartite_matching"],
     python_requires=">=3.6",
     setup_requires=[
         "wheel",


### PR DESCRIPTION
Testing the built package would be nice, but it's a bit complicated.
There are three options probably:
 - install the local wheel on the CI and then rename the "abcvoting"
 folder to something else to avoid that files are imported from there
 - set a fancy PYTHONPATH which prioritizes the installation location
 over the local folder - not sure how to do this on Github...
 - make another GH Action job which downloads the wheel from pypi and
 tests it by running only example scripts or so, we would need to
 rewrite examples a bit, because they need to be standalone scripts without being imported.
