### PR TITLE
Weighted rules & weighted properties

### DIFF
--- a/abcvoting/abcrules_ortools.py
+++ b/abcvoting/abcrules_ortools.py
@@ -66,7 +66,6 @@ def _optimize_rule_ortools(
     )
 
     while True:
-
         solver = cp_model.CpSolver()
         status = solver.Solve(model)
 

--- a/abcvoting/fileio.py
+++ b/abcvoting/fileio.py
@@ -50,7 +50,7 @@ def get_file_names(dir_name, filename_extensions=None):
             List of file names contained in the directory.
     """
     files = []
-    for (_, _, filenames) in os.walk(dir_name):
+    for _, _, filenames in os.walk(dir_name):
         files = filenames
         break  # do not consider sub-directories
     if len(files) == 0:

--- a/abcvoting/preferences.py
+++ b/abcvoting/preferences.py
@@ -134,7 +134,7 @@ class Profile:
         for voter in voters:
             self.add_voter(voter)
 
-    def totalweight(self):
+    def total_weight(self):
         """
         Return the totol weight of all voters, i.e., the sum of weights.
 
@@ -300,7 +300,7 @@ class Profile:
             )
         output = output[:-2]
         if not self.has_unit_weights():
-            output += "\ntotal weight: " + str(self.totalweight())
+            output += "\ntotal weight: " + str(self.total_weight())
         output += "\n"
 
         return output

--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -1208,9 +1208,6 @@ def test_jansonexamples(rule_id, algorithm):
     )
     assert committees == [{a, b, q}]
 
-    if rule_id == "phragmen-enestroem":
-        # only supports unit weights
-        return
     profile.convert_to_weighted()
     committees = abcrules.compute(
         rule_id, profile, committeesize, algorithm=algorithm, resolute=False

--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -1393,7 +1393,9 @@ only_defined_for_unit_weights = [
     abc_yaml_instances,
     ids=id_function,
 )
-def test_converted_to_weighted_abc_yaml_instances(filename, rule_id, algorithm, load_abc_yaml_file):
+def test_converted_to_weighted_abc_yaml_instances(
+    filename, rule_id, algorithm, load_abc_yaml_file
+):
     # skip tests involving CBC and minimaxphragmen that are known to fail
     if rule_id == "minimaxphragmen" and algorithm == "mip-cbc":
         if "instanceL0145.abc.yaml" in filename or "instanceL0153.abc.yaml" in filename:

--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -1393,7 +1393,7 @@ only_defined_for_unit_weights = [
     abc_yaml_instances,
     ids=id_function,
 )
-def converted_to_weighted_abc_yaml_instances(filename, rule_id, algorithm, load_abc_yaml_file):
+def test_converted_to_weighted_abc_yaml_instances(filename, rule_id, algorithm, load_abc_yaml_file):
     # skip tests involving CBC and minimaxphragmen that are known to fail
     if rule_id == "minimaxphragmen" and algorithm == "mip-cbc":
         if "instanceL0145.abc.yaml" in filename or "instanceL0153.abc.yaml" in filename:

--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -1404,12 +1404,9 @@ def converted_to_weighted_abc_yaml_instances(filename, rule_id, algorithm, load_
         return
     if len(profile) == profile.total_weight:
         return  # no need to test this instance
-    profile_copy = Profile(profile.num_cand)
-    for voter in profile:
-        profile_copy.add_voter(voter)
-    profile = profile_copy
-    profile.convert_to_weighted()
-    assert not profile.has_unit_weights()
+    weighted_profile = profile.copy()
+    weighted_profile.convert_to_weighted()
+    assert not weighted_profile.has_unit_weights()
 
     for compute_instance in compute_instances:
         if compute_instance["rule_id"] != rule_id:
@@ -1419,7 +1416,7 @@ def converted_to_weighted_abc_yaml_instances(filename, rule_id, algorithm, load_
 
         abcrules.compute(
             rule_id=compute_instance["rule_id"],
-            profile=profile,
+            profile=weighted_profile,
             committeesize=committeesize,
             result=compute_instance["result"],
             algorithm=algorithm,

--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -805,11 +805,10 @@ def test_abcrules_weightsconsidered(rule_id, algorithm, resolute):
 
     if rule_id in [
         "lexminimaxav",
-        "phragmen-enestroem",
         "rsd",
         "monroe",
         "greedy-monroe",
-    ] or rule_id.startswith("equal-shares"):
+    ]:
         with pytest.raises(ValueError):
             abcrules.compute(rule_id, profile, committeesize, algorithm=algorithm)
         return

--- a/tests/test_abcrules.py
+++ b/tests/test_abcrules.py
@@ -1402,7 +1402,7 @@ def converted_to_weighted_abc_yaml_instances(filename, rule_id, algorithm, load_
     profile, committeesize, compute_instances = load_abc_yaml_file[filename]
     if rule_id in only_defined_for_unit_weights:
         return
-    if len(profile) == profile.total_weight:
+    if len(profile) == profile.total_weight():
         return  # no need to test this instance
     weighted_profile = profile.copy()
     weighted_profile.convert_to_weighted()

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -101,8 +101,12 @@ def test_unitweights(num_cand):
 
     profile.add_voter(Voter([0, 4, 5], 2.4))
     assert not profile.has_unit_weights()
-
     assert profile.total_weight() == 6.4
+
+    with pytest.raises(TypeError):
+        # requires integer weights
+        profile.convert_to_unit_weights()
+
 
 
 @pytest.mark.parametrize("num_cand", [6, 7])
@@ -142,3 +146,22 @@ def test_approved_candidates():
     assert profile.approved_candidates() == {0, 1, 3, 4, 5, 7, 8}
     profile[0].approved = [1, 5]
     assert profile.approved_candidates() == {0, 1, 4, 5, 7, 8}
+
+def test_copy_profile():
+    profile = Profile(10)
+    profile.add_voter(Voter([1, 3, 5], 3))
+    profile.add_voter(Voter([2]))
+    copy = profile.copy()
+    assert profile.num_cand == copy.num_cand
+    for voter, voter_copy in zip(profile, copy):
+        assert voter.approved == voter_copy.approved
+        assert voter.weight == voter_copy.weight
+        assert voter is not voter_copy
+    copy.add_voter(Voter([4], 2))
+    assert len(profile) != len(copy)
+
+def test_voter_str():
+    v = Voter({0,1})
+    assert str(v) == '{0, 1}'
+    assert v.str_with_names() == '{0, 1}'
+    assert v.str_with_names({0: 'hello', 1: 'world'}) == '{hello, world}'

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -80,22 +80,22 @@ def test_unitweights(num_cand):
     assert profile.has_unit_weights()
 
     assert len(profile) == 4
-    assert profile.totalweight() == 4
+    assert profile.total_weight() == 4
 
     profile.convert_to_weighted()
     assert len(profile) == 2
-    assert profile.totalweight() == 4
+    assert profile.total_weight() == 4
     assert not profile.has_unit_weights()
 
     profile.convert_to_unit_weights()
     assert len(profile) == 4
-    assert profile.totalweight() == 4
+    assert profile.total_weight() == 4
     assert profile.has_unit_weights()
 
     profile.add_voter(Voter([0, 4, 5], 2.4))
     assert not profile.has_unit_weights()
 
-    assert profile.totalweight() == 6.4
+    assert profile.total_weight() == 6.4
 
 
 @pytest.mark.parametrize("num_cand", [6, 7])

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -108,7 +108,6 @@ def test_unitweights(num_cand):
         profile.convert_to_unit_weights()
 
 
-
 @pytest.mark.parametrize("num_cand", [6, 7])
 def test_iterate(num_cand):
     profile = Profile(num_cand)
@@ -147,6 +146,7 @@ def test_approved_candidates():
     profile[0].approved = [1, 5]
     assert profile.approved_candidates() == {0, 1, 4, 5, 7, 8}
 
+
 def test_copy_profile():
     profile = Profile(10)
     profile.add_voter(Voter([1, 3, 5], 3))
@@ -160,8 +160,9 @@ def test_copy_profile():
     copy.add_voter(Voter([4], 2))
     assert len(profile) != len(copy)
 
+
 def test_voter_str():
-    v = Voter({0,1})
-    assert str(v) == '{0, 1}'
-    assert v.str_with_names() == '{0, 1}'
-    assert v.str_with_names({0: 'hello', 1: 'world'}) == '{hello, world}'
+    v = Voter({0, 1})
+    assert str(v) == "{0, 1}"
+    assert v.str_with_names() == "{0, 1}"
+    assert v.str_with_names({0: "hello", 1: "world"}) == "{hello, world}"

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -57,6 +57,13 @@ def test_invalidprofiles(num_cand):
         profile.add_voter([[0, 4, 5]])
 
 
+def test_invalidweights():
+    with pytest.raises(ValueError):
+        Voter([0, 4, 5], weight=-1)
+    with pytest.raises(ValueError):
+        Voter([0, 4, 5], weight=0)
+
+
 @pytest.mark.parametrize("num_cand", [6, 7])
 def test_empty_approval(num_cand):
     profile = Profile(num_cand)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -539,10 +539,10 @@ def test_non_existent_property():
     with pytest.raises(ValueError):
         properties.check("a_property_that_does_not_exist", profile, {0})
 
+
 def test_props_that_do_not_need_quota():
     profile = Profile(3)
     props = ["pareto", "priceability", "stable-priceability"]
     for prop in props:
         with pytest.raises(ValueError):
             properties.check(prop, profile, {0}, quota=1)
-

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -532,3 +532,17 @@ def test_quota_properties(property_name, algorithm):
     assert properties.check(
         property_name, profile, committee=[0, 1, 2], quota=10 / 6, algorithm=algorithm
     )
+
+
+def test_non_existent_property():
+    profile = Profile(3)
+    with pytest.raises(ValueError):
+        properties.check("a_property_that_does_not_exist", profile, {0})
+
+def test_props_that_do_not_need_quota():
+    profile = Profile(3)
+    props = ["pareto", "priceability", "stable-priceability"]
+    for prop in props:
+        with pytest.raises(ValueError):
+            properties.check(prop, profile, {0}, quota=1)
+

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -298,7 +298,7 @@ def test_property_functions_with_handcrafted_instances(
             return  # not supported
         else:
             if convert_to_weighted:
-                if len(profile) == profile.total_weight:
+                if len(profile) == profile.total_weight():
                     return  # no need to test this instance
                 weighted_profile = profile.copy()
                 weighted_profile.convert_to_weighted()

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -298,19 +298,18 @@ def test_property_functions_with_handcrafted_instances(
             return  # not supported
         else:
             if convert_to_weighted:
-                original_length = len(profile)
-                profile_copy = Profile(profile.num_cand)
-                for voter in profile:
-                    profile_copy.add_voter(voter)
-                profile = profile_copy
-                profile.convert_to_weighted()
-                if len(profile) == original_length:
+                if len(profile) == profile.total_weight:
                     return  # no need to test this instance
-                assert not profile.has_unit_weights()
-            print(profile)
+                weighted_profile = profile.copy()
+                weighted_profile.convert_to_weighted()
+                assert not weighted_profile.has_unit_weights()
+                profile_to_use = weighted_profile
+            else:
+                profile_to_use = profile
+            print(profile_to_use)
             print(committee)
             assert (
-                properties.check(property_name, profile, committee, algorithm=algorithm)
+                properties.check(property_name, profile_to_use, committee, algorithm=algorithm)
                 == expected_result
             )
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -275,11 +275,12 @@ abc_yaml_filenames = _list_abc_yaml_instances()
     "algorithm",
     ["brute-force", "fastest", pytest.param("gurobi", marks=pytest.mark.gurobipy), "nonsense"],
 )
+@pytest.mark.parametrize("convert_to_weighted", [True, False], ids=["weighted", "unweighted"])
 @pytest.mark.parametrize(
     "property_name, profile, committee, expected_result", check_property_instances
 )
 def test_property_functions_with_handcrafted_instances(
-    property_name, algorithm, profile, committee, expected_result
+    property_name, algorithm, convert_to_weighted, profile, committee, expected_result
 ):
     output.set_verbosity(verbosity=DETAILS)
 
@@ -291,7 +292,21 @@ def test_property_functions_with_handcrafted_instances(
     else:
         if algorithm == "brute-force" and property_name in ["priceability", "stable-priceability"]:
             return  # not supported
+        elif (
+            convert_to_weighted and algorithm == "brute-force" and property_name in ["ejr", "pjr"]
+        ):
+            return  # not supported
         else:
+            if convert_to_weighted:
+                original_length = len(profile)
+                profile_copy = Profile(profile.num_cand)
+                for voter in profile:
+                    profile_copy.add_voter(voter)
+                profile = profile_copy
+                profile.convert_to_weighted()
+                if len(profile) == original_length:
+                    return  # no need to test this instance
+                assert not profile.has_unit_weights()
             print(profile)
             print(committee)
             assert (
@@ -340,11 +355,18 @@ def test_matching_output_different_approaches_and_implications(abc_yaml_instance
     assert brute_force_PJR == properties.check_PJR(profile, input_committee, algorithm="gurobi")
 
     # check logical implications
+    is_priceable = properties.check_priceability(profile, input_committee)
+    is_stable_priceable = properties.check_stable_priceability(profile, input_committee)
     is_EJR_plus = properties.check_EJR_plus(profile, input_committee)
     is_JR = properties.check_JR(profile, input_committee)
+    # see Hasse diagram in Fig. 4.1 of
+    # "Multi-Winner Voting with Approval Preferences", Lackner and Skowron, 2023
     logical_implications = [
+        (is_stable_priceable, is_priceable),
+        (is_stable_priceable, brute_force_core),
         (brute_force_core, brute_force_FJR),
         (brute_force_FJR, brute_force_EJR),
+        (is_priceable, brute_force_PJR),
         (brute_force_EJR, brute_force_PJR),
         (brute_force_PJR, is_JR),
         (is_EJR_plus, brute_force_EJR),
@@ -354,6 +376,20 @@ def test_matching_output_different_approaches_and_implications(abc_yaml_instance
             assert conclusion
         if not conclusion:
             assert not premise
+
+    # check that output remain the same if weighted
+    original_length = len(profile)
+    profile.convert_to_weighted()
+    if len(profile) == original_length:
+        return  # no need to test this instance
+    assert is_priceable == properties.check_priceability(profile, input_committee)
+    assert is_stable_priceable == properties.check_stable_priceability(profile, input_committee)
+    assert brute_force_core == properties.check_core(profile, input_committee)
+    assert brute_force_FJR == properties.check_FJR(profile, input_committee)
+    assert brute_force_EJR == properties.check_EJR(profile, input_committee)
+    assert brute_force_PJR == properties.check_PJR(profile, input_committee)
+    assert is_EJR_plus == properties.check_EJR_plus(profile, input_committee)
+    assert is_JR == properties.check_JR(profile, input_committee)
 
 
 @pytest.mark.gurobipy
@@ -413,14 +449,14 @@ def test_properties_with_rules(rule_id, property_name, abc_yaml_instance):
         assert properties.check(property_name, profile, committee)
 
 
-# Test from literature: Lackner and Skowron 2020
-# With given input profile, committee returned by Monroe Rule
-# is not Pareto optimal
 @pytest.mark.parametrize(
     "algorithm", ["brute-force", pytest.param("gurobi", marks=pytest.mark.gurobipy)]
 )
 def test_pareto_optimality_methods(algorithm):
     output.set_verbosity(verbosity=DETAILS)
+
+    # Test from literature: Lackner and Skowron 2020
+    # Example where Monroe's Rule is not Pareto optimal
 
     # profile with 4 candidates: a, b, c, d
     profile = Profile(4)
@@ -443,6 +479,14 @@ def test_pareto_optimality_methods(algorithm):
     assert not is_pareto_optimal
 
     assert properties.check_pareto_optimality(profile, {0, 1}, algorithm=algorithm)
+
+    # Lackner and Skowron 2020
+    # Example where Phragmén's Rule is not Pareto optimal
+    profile = Profile(5)
+    profile.add_voters([{0, 2, 4}] * 10 + [{0, 1, 4}] * 9 + [{0, 1}] + [{1, 3}] * 8 + [{2, 3}] * 8)
+    phragmen_output = abcrules.compute_seqphragmen(profile, 3)
+    assert phragmen_output == [{0, 3, 4}]
+    assert not properties.check_pareto_optimality(profile, {0, 3, 4}, algorithm=algorithm)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* generalize property checks to weighted profiles
   * I did not implement weighted `brute-force` checks for PJR and EJR, since those require design decisions (currently, these iterate over voter groups of specific size; with weights we would probably need to iterate over all subsets of voters or switch to iterating over subsets of candidates)
* weighted rules:
    * remove `NotImplementedError` for `phragmen-enestrom` for weighted profile (was actually already implemented)
    * fix weighted version of `consensus-rule`
    * generalize `equal-shares` (and its variants) to work for weighted profiles
* test weighted rules and weighted property checks using `convert_to_weighted` (property truth values and rule outputs should be invariant under this operation)

It's probably best to wait a few days before merging this PR to see whether anything comes up.