### PR TITLE
Property tests for PJR and EJR work with brute force and weighted profiles

### DIFF
--- a/abcvoting/properties.py
+++ b/abcvoting/properties.py
@@ -293,12 +293,6 @@ def check_EJR(profile, committee, quota=None, algorithm="fastest"):
     if algorithm == "fastest":
         algorithm = "gurobi"
 
-    if not profile.has_unit_weights() and algorithm == "brute-force":
-        raise NotImplementedError(
-            "For profiles with non-unit weights, "
-            "check_EJR currently only supports the algorithm 'gurobi'."
-        )
-
     if algorithm == "brute-force":
         result, detailed_information = _check_EJR_brute_force(profile, committee, quota)
     elif algorithm == "gurobi":
@@ -408,12 +402,6 @@ def check_PJR(profile, committee, quota=None, algorithm="fastest"):
 
     if algorithm == "fastest":
         algorithm = "gurobi"
-
-    if not profile.has_unit_weights() and algorithm == "brute-force":
-        raise NotImplementedError(
-            "For profiles with non-unit weights, check_PJR "
-            "currently only supports the algorithm 'gurobi'."
-        )
 
     if algorithm == "brute-force":
         result, detailed_information = _check_PJR_brute_force(profile, committee, quota)
@@ -1321,7 +1309,10 @@ def _check_priceability_gurobi(profile, committee, stable=False):
             output.details(f"Budget: {budget.X}")
 
             column_widths = {
-                candidate: max(len(str(payment[voter][candidate].X)) for voter in payment)
+                candidate: max(
+                    len(str(candidate)),
+                    max(len(str(payment[voter][candidate].X)) for voter in payment),
+                )
                 for candidate in profile.candidates
             }
             column_widths["voter"] = len(str(len(profile)))

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -292,10 +292,6 @@ def test_property_functions_with_handcrafted_instances(
     else:
         if algorithm == "brute-force" and property_name in ["priceability", "stable-priceability"]:
             return  # not supported
-        elif (
-            convert_to_weighted and algorithm == "brute-force" and property_name in ["ejr", "pjr"]
-        ):
-            return  # not supported
         else:
             if convert_to_weighted:
                 if len(profile) == profile.total_weight():


### PR DESCRIPTION
The property testers all support weighted profiles, but for PJR and EJR the code assumed this is not the case. I removed the relevant if-clauses.