### PR TITLE
Add links to the GitHub repository from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,8 @@
 abcvoting
 =========
 
-`abcvoting` is a Python library of approval-based committee (ABC) rules.
+`abcvoting <https://github.com/martinlackner/abcvoting>`_ is a Python library 
+of approval-based committee (ABC) rules.
 ABC rules are also known as approval-based multi-winner rules.
 The input of such rules are
 `approval ballots <https://en.wikipedia.org/wiki/Approval_voting#/media/File:Approval_ballot.svg>`_.
@@ -43,6 +44,7 @@ is useful as a more general introduction to committee voting.
 
    howtocite.rst
    acks.rst
+   GitHub repository <https://github.com/martinlackner/abcvoting>
 
 Indices and tables
 ==================


### PR DESCRIPTION
Currently it is difficult to get from the documentation to the GitHub repository, so I added a link to `https://github.com/martinlackner/abcvoting/` from the first word on the home page, and adding a link to the bottom of the table of contents.

<img width="800" alt="Screenshot 2025-02-20 at 14 17 56" src="https://github.com/user-attachments/assets/71143f59-aa32-4812-bd28-9374190b80ce" />
