### PR TITLE
Fix GitHub Actions output variable syntax in piptest workflow

### DIFF
--- a/.github/workflows/piptest.yml
+++ b/.github/workflows/piptest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: get latest release with tag
         id: latestrelease
         run: |
-          echo "{releasetag}=$(curl -s https://api.github.com/repos/martinlackner/abcvoting/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
+          echo "releasetag=$(curl -s https://api.github.com/repos/martinlackner/abcvoting/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
       - name: confirm release tag
         run: |
           echo ${{ steps.latestrelease.outputs.releasetag }}


### PR DESCRIPTION
## Summary
Fixed a syntax error in the GitHub Actions workflow that was preventing the release tag from being properly captured and output.

## Changes
- **Fixed output variable syntax**: Corrected `{releasetag}` to `releasetag` in the GitHub Actions output command
  - The curly braces were causing the variable assignment to fail
  - This was preventing the latest release tag from being properly stored in the workflow output

## Details
The issue was in the `get latest release with tag` step where the output variable was being set with incorrect syntax. GitHub Actions expects the format `name=value` without curly braces around the variable name. This fix ensures that the release tag retrieved from the GitHub API is correctly captured and can be referenced in subsequent workflow steps via `${{ steps.latestrelease.outputs.releasetag }}`.

https://claude.ai/code/session_01QZtK7RAKHhm2o5oDREzsru