### PR TITLE
Use python -m pytest instead of pytest command in CI workflows

### DIFF
--- a/.github/workflows/piptest.yml
+++ b/.github/workflows/piptest.yml
@@ -49,4 +49,4 @@ jobs:
           echo $PYTHONPATH
           export PYTHONPATH=$PYTHONPATH:$PWD
           echo $PYTHONPATH
-          pytest -v --tb=long -m "not mip and (not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/
+          python -m pytest -v --tb=long -m "not mip and (not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/

--- a/.github/workflows/piptestfull.yml
+++ b/.github/workflows/piptestfull.yml
@@ -37,4 +37,4 @@ jobs:
           echo $PYTHONPATH
           export PYTHONPATH=$PYTHONPATH:$PWD
           echo $PYTHONPATH
-          pytest -v --tb=long -m "not mip and (not gurobipy or not slow) and not veryslow" -ra tests/
+          python -m pytest -v --tb=long -m "not mip and (not gurobipy or not slow) and not veryslow" -ra tests/


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflows to invoke pytest using `python -m pytest` instead of the direct `pytest` command.

## Changes
- Modified `.github/workflows/piptest.yml` to use `python -m pytest`
- Modified `.github/workflows/piptestfull.yml` to use `python -m pytest`

## Details
This change ensures pytest is executed through the Python module interface rather than relying on the pytest executable being in the PATH. This approach is more reliable in CI environments as it:
- Guarantees the pytest module is run with the same Python interpreter used to install dependencies
- Avoids potential PATH resolution issues in containerized or restricted CI environments
- Follows pytest's recommended invocation method for programmatic and CI usage

https://claude.ai/code/session_01LqCTmCvJtvvgpMcD6dDdPs