### PR TITLE
Reduce pytest verbosity and simplify test output formatting

### DIFF
--- a/.github/workflows/piptest.yml
+++ b/.github/workflows/piptest.yml
@@ -49,4 +49,4 @@ jobs:
           echo $PYTHONPATH
           export PYTHONPATH=$PYTHONPATH:$PWD
           echo $PYTHONPATH
-          python -m pytest -v --tb=long -m "not mip and (not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/
+          python -m pytest -q --tb=short -m "not mip and (not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/

--- a/.github/workflows/piptestfull.yml
+++ b/.github/workflows/piptestfull.yml
@@ -37,4 +37,4 @@ jobs:
           echo $PYTHONPATH
           export PYTHONPATH=$PYTHONPATH:$PWD
           echo $PYTHONPATH
-          python -m pytest -v --tb=long -m "not mip and (not gurobipy or not slow) and not veryslow" -ra tests/
+          python -m pytest -q --tb=short -m "not mip and (not gurobipy or not slow) and not veryslow" -ra tests/

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        coverage run --source=. -m pytest -v --tb=long -m "not mip and (not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/
+        coverage run --source=. -m pytest -q --tb=short -m "not mip and (not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/
 
     - name: Generate coverage report
       run: coverage xml


### PR DESCRIPTION
## Summary
This PR reduces the verbosity of pytest output across all CI/CD workflows by changing output flags and traceback formatting to make test results more concise and easier to read.

## Key Changes
- Changed pytest verbosity flag from `-v` (verbose) to `-q` (quiet) in all three workflow files
- Changed traceback format from `--tb=long` to `--tb=short` for more concise error output

## Details
These changes apply to:
- `.github/workflows/piptest.yml` - Standard pip test workflow
- `.github/workflows/piptestfull.yml` - Full pip test workflow
- `.github/workflows/unittests.yml` - Unit tests with coverage workflow

The modifications reduce noise in CI/CD logs while still maintaining visibility into test failures, making it easier to identify and debug issues in pull request checks.

https://claude.ai/code/session_01Qda6XSnPJsUGoPcjpfjXC6