### PR TITLE
Update GitHub Actions to use latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on:
       tags:
         - v*
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,18 +18,15 @@ on:
       tags:
         - v*
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 

--- a/.github/workflows/deploy-benchmark-dashboard.yml
+++ b/.github/workflows/deploy-benchmark-dashboard.yml
@@ -18,6 +18,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-benchmark-dashboard.yml
+++ b/.github/workflows/deploy-benchmark-dashboard.yml
@@ -18,9 +18,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,7 +26,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/.github/workflows/piptest.yml
+++ b/.github/workflows/piptest.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 5 * * *'  # every day at 5:00
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   unittests:
 
@@ -25,12 +22,12 @@ jobs:
         run: |
           echo ${{ steps.latestrelease.outputs.releasetag }}
       - name: tagcheckout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.latestrelease.outputs.releasetag }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/piptest.yml
+++ b/.github/workflows/piptest.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 5 * * *'  # every day at 5:00
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   unittests:
 

--- a/.github/workflows/piptestfull.yml
+++ b/.github/workflows/piptestfull.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 20 * * Tue'  # every Tuesday
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   unittests:
 
@@ -17,13 +14,13 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch all tags to be able to generate a version number for test packages
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/piptestfull.yml
+++ b/.github/workflows/piptestfull.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 20 * * Tue'  # every Tuesday
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   unittests:
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,6 +12,9 @@ on:
   workflow_dispatch:
     branches: [ "master" ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   unittests:
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,9 +12,6 @@ on:
   workflow_dispatch:
     branches: [ "master" ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   unittests:
 
@@ -25,13 +22,13 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # fetch all tags to be able to generate a version number for test packages
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
This pull request updates GitHub Actions workflow files to use the latest versions of commonly used actions across all CI/CD pipelines.

## Key Changes
- Updated `actions/checkout` from v4 to v6 across all workflow files:
  - `.github/workflows/build.yml`
  - `.github/workflows/piptest.yml`
  - `.github/workflows/piptestfull.yml`
  - `.github/workflows/unittests.yml`
  - `.github/workflows/deploy-benchmark-dashboard.yml`

- Updated `actions/setup-python` from v5 to v6 across all workflow files:
  - `.github/workflows/build.yml`
  - `.github/workflows/piptest.yml`
  - `.github/workflows/piptestfull.yml`
  - `.github/workflows/unittests.yml`

## Details
These updates ensure that all CI/CD pipelines benefit from the latest features, bug fixes, and security improvements provided by the GitHub Actions team. The changes are applied consistently across all workflow files to maintain uniformity in the CI/CD infrastructure.

https://claude.ai/code/session_015Br4Cbh2KgdTKYHjAgKsjV