### PR TITLE
Update PuLP solver configuration and test settings

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        coverage run --source=. -m pytest -q --tb=short -m "(not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/
+        coverage run --source=. -m pytest -q --tb=short -W error -m "(not gurobipy or not slow) and (not ortools or not slow) and not veryslow" -ra tests/
 
     - name: Generate coverage report
       run: coverage xml

--- a/abcvoting/abcrules_pulp.py
+++ b/abcvoting/abcrules_pulp.py
@@ -241,7 +241,7 @@ def get_solver(solver_id):
     if solver_id == "highs":
         return pulp.HiGHS(msg=False)
     elif solver_id == "cbc":
-        return pulp.PULP_CBC_CMD(msg=False)
+        return pulp.COIN_CMD(msg=False)
     else:
         raise ValueError(f"Solver {solver_id} not known in Python Pulp.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "preflibtools>=2.0.12",
     "prefsampling>=0.1.19",
     "pabutools>=1.1.15",
-    "pulp[open_py]>=3.2",
+    "pulp[open_py,cbc]>=3.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ packages = ["abcvoting"]
 addopts = '''
 -ra
 --tb=line
--W error
 --doctest-modules
 --strict-markers
 '''


### PR DESCRIPTION
## Summary
This PR updates the PuLP solver configuration and adjusts test warning handling to improve compatibility and test robustness.

## Key Changes
- **PuLP dependency**: Added `cbc` extra to the PuLP dependency specification (`pulp[open_py,cbc]>=3.2`) to ensure the CBC solver is available
- **Solver API update**: Changed CBC solver instantiation from deprecated `pulp.PULP_CBC_CMD` to `pulp.COIN_CMD` in `abcrules_pulp.py`
- **Test configuration**: Moved the `-W error` flag from `pyproject.toml` pytest configuration to the GitHub Actions test command, allowing warnings during local development while enforcing strict warning handling in CI

## Implementation Details
The changes ensure that:
1. The CBC solver dependency is explicitly declared and available when needed
2. The code uses the current PuLP API for CBC solver access
3. CI pipelines maintain strict warning enforcement while developers have more flexibility locally

https://claude.ai/code/session_01Scu8KVjUa6gmfbSpCE2bgN