### PR TITLE
Use bundled CBC binary instead of system cbc in PuLP solver

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
       with:
         # fetch all tags to be able to generate a version number for test packages
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # fetch all tags to be able to generate a version number for test packages
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/abcvoting/abcrules_pulp.py
+++ b/abcvoting/abcrules_pulp.py
@@ -240,7 +240,12 @@ def get_solver(solver_id):
     if solver_id == "highs":
         return pulp.HiGHS(msg=False)
     elif solver_id == "cbc":
-        return pulp.COIN_CMD(msg=False)
+        # Use the stable bundled CBC binary rather than any system `cbc`
+        # (e.g. cbcbox), which may be an unstable build that crashes in
+        # symmetry detection when re-solving a modified problem.
+        from pulp.apis.coin_api import pulp_cbc_path
+
+        return pulp.COIN_CMD(msg=False, path=pulp_cbc_path)
     else:
         raise ValueError(f"Solver {solver_id} not known in Python Pulp.")
 

--- a/abcvoting/abcrules_pulp.py
+++ b/abcvoting/abcrules_pulp.py
@@ -243,6 +243,7 @@ def get_solver(solver_id):
         # Use the stable bundled CBC binary rather than any system `cbc`
         # (e.g. cbcbox), which may be an unstable build that crashes in
         # symmetry detection when re-solving a modified problem.
+        # TODO: remove the path override once cbcbox ships a stable CBC build
         from pulp.apis.coin_api import pulp_cbc_path
 
         return pulp.COIN_CMD(msg=False, path=pulp_cbc_path)


### PR DESCRIPTION
## Summary
Modified the CBC solver initialization in PuLP to explicitly use the stable bundled CBC binary instead of relying on any system-installed `cbc` executable.

## Key Changes
- Updated `get_solver()` function to pass the `path=pulp_cbc_path` parameter when creating `pulp.COIN_CMD` instances for CBC solver
- Added import of `pulp_cbc_path` from `pulp.apis.coin_api` to reference the bundled binary
- Added explanatory comment documenting why this change is necessary

## Implementation Details
The change addresses an issue where system-installed CBC builds (such as cbcbox) may be unstable and crash during symmetry detection when re-solving modified problems. By explicitly pointing to PuLP's bundled CBC binary, we ensure consistent and stable behavior across different environments. A TODO comment notes that this override can be removed once cbcbox ships a stable CBC build.

https://claude.ai/code/session_01WB3kJ5V9gTucNBFeAPcfbT